### PR TITLE
Publish the package only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ deploy:
   script:
     - make publish
   on:
+    python: 3.7
     tags: true
 
 branches:


### PR DESCRIPTION
In the current configuration, three deployments are performed, but only the first one succeeds.
Therefore, change the deployment to run only once.

https://travis-ci.com/speg03/nestargs/builds/116038687