### PR TITLE
Add option decorator

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -88,3 +88,32 @@ banana = total_price(**vars(args.banana))
 print(apple + banana)
 # => 13.5
 ```
+
+### option デコレータ
+
+対象の関数に `option` デコレータを付与することで、プログラム引数の設定を追加することができます。追加できる設定は `argparse` の `ArgumentParser.add_argument` に基づきます。
+
+```python
+@nestargs.option("n", help="number of ingredients")
+@nestargs.option("price", help="unit price of ingredients")
+def total_price(n=1, price=1.0):
+    return n * price
+
+
+parser = nestargs.NestedArgumentParser()
+parser.register_arguments(total_price, prefix="apple")
+```
+
+このコードは次のコードと等価です。
+
+```python
+def total_price(n=1, price=1.0):
+    return n * price
+
+
+parser = nestargs.NestedArgumentParser()
+parser.add_argument("--apple.n", type=int, default=1, help="number of ingredients")
+parser.add_argument(
+    "--apple.price", type=float, default=1.0, help="unit price of ingredients"
+)
+```

--- a/README.md
+++ b/README.md
@@ -90,3 +90,32 @@ banana = total_price(**vars(args.banana))
 print(apple + banana)
 # => 13.5
 ```
+
+### Option decorator
+
+Program argument settings can be added by attaching an `option` decorator to the target function. The settings that can be added are based on `ArgumentParser.add_argument` of `argparse`.
+
+```python
+@nestargs.option("n", help="number of ingredients")
+@nestargs.option("price", help="unit price of ingredients")
+def total_price(n=1, price=1.0):
+    return n * price
+
+
+parser = nestargs.NestedArgumentParser()
+parser.register_arguments(total_price, prefix="apple")
+```
+
+This code is equivalent to the following code:
+
+```python
+def total_price(n=1, price=1.0):
+    return n * price
+
+
+parser = nestargs.NestedArgumentParser()
+parser.add_argument("--apple.n", type=int, default=1, help="number of ingredients")
+parser.add_argument(
+    "--apple.price", type=float, default=1.0, help="unit price of ingredients"
+)
+```

--- a/nestargs/__init__.py
+++ b/nestargs/__init__.py
@@ -1,3 +1,4 @@
 __version__ = "0.3.0"
 
+from .decorators import option  # noqa: F401
 from .parser import NestedArgumentParser  # noqa: F401

--- a/nestargs/decorators.py
+++ b/nestargs/decorators.py
@@ -1,0 +1,9 @@
+from .meta import set_metadata
+
+
+def option(parameter_name, **arg_params):
+    def decorator(f):
+        set_metadata(f, parameter_name, "arg_params", arg_params)
+        return f
+
+    return decorator

--- a/nestargs/decorators.py
+++ b/nestargs/decorators.py
@@ -1,8 +1,15 @@
+import inspect
+
 from .meta import set_metadata
 
 
 def option(parameter_name, **arg_params):
     def decorator(f):
+        sig = inspect.signature(f)
+        if parameter_name not in sig.parameters:
+            raise ValueError(
+                "{} doesn't have a parameter: {}".format(f.__name__, parameter_name)
+            )
         set_metadata(f, parameter_name, "arg_params", arg_params)
         return f
 

--- a/nestargs/meta.py
+++ b/nestargs/meta.py
@@ -1,0 +1,14 @@
+ATTRIBUTE = "__nestargs__"
+
+
+def set_metadata(function, parameter_name, key, value):
+    if not hasattr(function, ATTRIBUTE):
+        setattr(function, ATTRIBUTE, {})
+    attr = getattr(function, ATTRIBUTE)
+    attr.setdefault(parameter_name, {})[key] = value
+
+
+def get_metadata(function, parameter_name, key):
+    if hasattr(function, ATTRIBUTE):
+        return getattr(function, ATTRIBUTE).get(parameter_name, {}).get(key)
+    return None

--- a/nestargs/parser.py
+++ b/nestargs/parser.py
@@ -1,6 +1,8 @@
 import argparse
 import inspect
 
+from .meta import get_metadata
+
 
 class NestedNamespace(argparse.Namespace):
     DELIMITER = "."
@@ -29,9 +31,8 @@ class NestedArgumentParser(argparse.ArgumentParser):
 
     def register_arguments(self, function, prefix=None):
         if inspect.isclass(function):
-            sig = inspect.signature(function.__init__)
-        else:
-            sig = inspect.signature(function)
+            function = function.__init__
+        sig = inspect.signature(function)
 
         if prefix:
             arg_prefix = prefix + "."
@@ -65,6 +66,10 @@ class NestedArgumentParser(argparse.ArgumentParser):
                     arg_params["type"] = type(parameter.default)
 
                 arg_params["default"] = parameter.default
+
+            override_arg_params = get_metadata(function, parameter.name, "arg_params")
+            if override_arg_params:
+                arg_params.update(override_arg_params)
 
             arg_name = self.prefix_chars[0] * 2 + arg_prefix + name
             actions[parameter.name] = target.add_argument(arg_name, **arg_params)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,3 +1,5 @@
+import pytest
+
 import nestargs
 from nestargs.meta import get_metadata
 
@@ -10,3 +12,10 @@ class TestOption:
 
         expected = {"nargs": 2, "help": "help for parameter"}
         assert get_metadata(some_function, "param", "arg_params") == expected
+
+    def test_option_with_invalid_parameter(self):
+        with pytest.raises(ValueError):
+
+            @nestargs.option("invalid", help="invalid parameter")
+            def some_function(param):
+                pass

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,12 @@
+import nestargs
+from nestargs.meta import get_metadata
+
+
+class TestOption:
+    def test_option(self):
+        @nestargs.option("param", nargs=2, help="help for parameter")
+        def some_function(param):
+            pass
+
+        expected = {"nargs": 2, "help": "help for parameter"}
+        assert get_metadata(some_function, "param", "arg_params") == expected

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,14 @@
+from nestargs.meta import get_metadata, set_metadata
+
+
+class TestMeta:
+    def test_get_metadata(self):
+        def some_function(param):
+            pass
+
+        assert get_metadata(some_function, "param", "arg_params") is None
+
+        expected = {"nargs": 2, "help": "help for parameter"}
+        set_metadata(some_function, "param", "arg_params", expected)
+
+        assert get_metadata(some_function, "param", "arg_params") == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -88,3 +88,18 @@ class TestNestedArgumentParser:
 
         args = parser.parse_args(["--some.param", "foo"])
         assert args.some.param == "foo"
+
+    def test_register_arguments_with_option_decorator(self):
+        @nestargs.option("param", nargs=2, help="help for parameter")
+        def some_function(param):
+            pass
+
+        parser = nestargs.NestedArgumentParser()
+
+        actions = parser.register_arguments(some_function, prefix="some")
+        assert actions.keys() == {"param"}
+        assert actions["param"].nargs == 2
+        assert actions["param"].help == "help for parameter"
+
+        args = parser.parse_args(["--some.param", "foo", "bar"])
+        assert args.some.param == ["foo", "bar"]


### PR DESCRIPTION
Program argument settings can be added by attaching an `option` decorator to the target function. The settings that can be added are based on `ArgumentParser.add_argument` of `argparse`.

```python
@nestargs.option("n", help="number of ingredients")
@nestargs.option("price", help="unit price of ingredients")
def total_price(n=1, price=1.0):
    return n * price


parser = nestargs.NestedArgumentParser()
parser.register_arguments(total_price, prefix="apple")
```
