### PR TITLE
Ignore parameters for register_arguments

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -117,3 +117,24 @@ parser.add_argument(
     "--apple.price", type=float, default=1.0, help="unit price of ingredients"
 )
 ```
+
+### ignores デコレータ
+
+対象の関数に `ignores` デコレータを付与することで、プログラム引数に登録しないパラメータを指定することができます。
+
+```python
+@nestargs.ignores("tax", "shipping")
+def total_price(n=1, price=1.0, tax=1.0, shipping=0.0):
+    return n * price * tax + shipping
+
+
+parser = nestargs.NestedArgumentParser()
+parser.register_arguments(total_price, prefix="apple")
+
+args = parser.parse_args(["--apple.n=2", "--apple.price=1.5"])
+# => NestedNamespace(apple=NestedNamespace(n=2, price=1.5))
+# taxとshippingパラメータが含まれていません
+
+apple = total_price(**vars(args.apple))
+# => 3.0
+```

--- a/README.md
+++ b/README.md
@@ -119,3 +119,24 @@ parser.add_argument(
     "--apple.price", type=float, default=1.0, help="unit price of ingredients"
 )
 ```
+
+### Ignores decorator
+
+By attaching an `ignores` decorator to the target function, you can specify parameters that do not register in the program arguments.
+
+```python
+@nestargs.ignores("tax", "shipping")
+def total_price(n=1, price=1.0, tax=1.0, shipping=0.0):
+    return n * price * tax + shipping
+
+
+parser = nestargs.NestedArgumentParser()
+parser.register_arguments(total_price, prefix="apple")
+
+args = parser.parse_args(["--apple.n=2", "--apple.price=1.5"])
+# => NestedNamespace(apple=NestedNamespace(n=2, price=1.5))
+# Not included tax and shipping parameters
+
+apple = total_price(**vars(args.apple))
+# => 3.0
+```

--- a/nestargs/__init__.py
+++ b/nestargs/__init__.py
@@ -1,4 +1,4 @@
 __version__ = "0.3.0"
 
-from .decorators import option  # noqa: F401
+from .decorators import ignores, option  # noqa: F401
 from .parser import NestedArgumentParser  # noqa: F401

--- a/nestargs/decorators.py
+++ b/nestargs/decorators.py
@@ -14,3 +14,17 @@ def option(parameter_name, **arg_params):
         return f
 
     return decorator
+
+
+def ignores(*parameter_names):
+    def decorator(f):
+        sig = inspect.signature(f)
+        for name in parameter_names:
+            if name not in sig.parameters:
+                raise ValueError(
+                    "{} doesn't have a parameter: {}".format(f.__name__, name)
+                )
+            set_metadata(f, name, "ignore", True)
+        return f
+
+    return decorator

--- a/nestargs/parser.py
+++ b/nestargs/parser.py
@@ -48,6 +48,7 @@ class NestedArgumentParser(argparse.ArgumentParser):
                 or parameter.name == "cls"
                 or parameter.kind is inspect.Parameter.VAR_POSITIONAL
                 or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                or get_metadata(function, parameter.name, "ignore")
             ):
                 continue  # pragma: no cover
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -19,3 +19,21 @@ class TestOption:
             @nestargs.option("invalid", help="invalid parameter")
             def some_function(param):
                 pass
+
+
+class TestIgnores:
+    def test_ignores(self):
+        @nestargs.ignores("param2", "param3")
+        def some_function(param1, param2, param3):
+            pass
+
+        assert get_metadata(some_function, "param1", "ignore") is None
+        assert get_metadata(some_function, "param2", "ignore") is True
+        assert get_metadata(some_function, "param3", "ignore") is True
+
+    def test_ignores_with_invalid_parameter(self):
+        with pytest.raises(ValueError):
+
+            @nestargs.ignores("invalid")
+            def some_function(param):
+                pass

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -103,3 +103,13 @@ class TestNestedArgumentParser:
 
         args = parser.parse_args(["--some.param", "foo", "bar"])
         assert args.some.param == ["foo", "bar"]
+
+    def test_register_arguments_with_ignores_decorator(self):
+        @nestargs.ignores("param2", "param3")
+        def some_function(param1, param2, param3):
+            pass
+
+        parser = nestargs.NestedArgumentParser()
+
+        actions = parser.register_arguments(some_function, prefix="some")
+        assert actions.keys() == {"param1"}


### PR DESCRIPTION
By attaching an `ignores` decorator to the target function, you can specify parameters that do not register in the program arguments.

```python
@nestargs.ignores("tax", "shipping")
def total_price(n=1, price=1.0, tax=1.0, shipping=0.0):
    return n * price * tax + shipping


parser = nestargs.NestedArgumentParser()
parser.register_arguments(total_price, prefix="apple")

args = parser.parse_args(["--apple.n=2", "--apple.price=1.5"])
# => NestedNamespace(apple=NestedNamespace(n=2, price=1.5))
# Not included tax and shipping parameters

apple = total_price(**vars(args.apple))
# => 3.0
```
