### PR TITLE
Get version from package metadata

### DIFF
--- a/nestargs/__init__.py
+++ b/nestargs/__init__.py
@@ -1,4 +1,9 @@
-__version__ = "0.4.2.dev0"
-
 from .decorators import ignores, option  # noqa: F401
 from .parser import NestedArgumentParser  # noqa: F401
+
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
+__version__ = version("nestargs")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.5"
+importlib-metadata = { version = "^1.5", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,6 @@
+import nestargs
+
+
+class TestInit:
+    def test_version(self):
+        assert nestargs.__version__


### PR DESCRIPTION
If you use Python 3.8 or upper, get version from `importlib.metadata`. Otherwise, from `importlib_metadata`.