### PR TITLE
Use python3 for poetry commands

### DIFF
--- a/.github/workflows/upload-python-package.yml
+++ b/.github/workflows/upload-python-package.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
     - uses: dschep/install-poetry-action@v1.3
 
     - name: Build
@@ -25,6 +26,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: master
+    - uses: actions/setup-python@v1
     - uses: dschep/install-poetry-action@v1.3
 
     - name: Update development version


### PR DESCRIPTION
Use python3 for some github actions using poetry instead of default python2.
The `setup-python` action sets up python 3.x as default.

This change will suppress the following message.
```
/home/runner/.poetry/lib/poetry/_vendor/py2.7/subprocess32.py:149: RuntimeWarning: The _posixsubprocess module is not being used. Child process reliability may suffer if your program uses threads.
  "program uses threads.", RuntimeWarning)
```