### PR TITLE
Use setup.cfg for configurations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 88

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --cov=nestargs --cov-report=term-missing --cov-report=xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88
+
+[tool:pytest]
+addopts = --cov=nestargs --cov-report=term-missing --cov-report=xml


### PR DESCRIPTION
black compatible configurations for flake8, isort and pytest
https://github.com/psf/black/blob/master/docs/compatible_configs.md