### PR TITLE
Improve the decorator not to raise ValueError when target function has **kwargs

### DIFF
--- a/nestargs/decorators.py
+++ b/nestargs/decorators.py
@@ -6,7 +6,11 @@ from .meta import set_metadata
 def option(parameter_name, **arg_params):
     def decorator(f):
         sig = inspect.signature(f)
-        if parameter_name not in sig.parameters:
+        if (
+            parameter_name not in sig.parameters
+            and inspect.Parameter.VAR_KEYWORD
+            not in (sig.parameters[k].kind for k in sig.parameters.keys())
+        ):
             raise ValueError(
                 "{} doesn't have a parameter: {}".format(f.__name__, parameter_name)
             )

--- a/nestargs/decorators.py
+++ b/nestargs/decorators.py
@@ -9,7 +9,7 @@ def option(parameter_name, **arg_params):
         if (
             parameter_name not in sig.parameters
             and inspect.Parameter.VAR_KEYWORD
-            not in (sig.parameters[k].kind for k in sig.parameters.keys())
+            not in {sig.parameters[k].kind for k in sig.parameters.keys()}
         ):
             raise ValueError(
                 "{} doesn't have a parameter: {}".format(f.__name__, parameter_name)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -13,6 +13,14 @@ class TestOption:
         expected = {"nargs": 2, "help": "help for parameter"}
         assert get_metadata(some_function, "param", "arg_params") == expected
 
+    def test_option_with_kwargs(self):
+        @nestargs.option("param", nargs=2, help="help for parameter")
+        def some_function(**kwargs):
+            pass
+
+        expected = {"nargs": 2, "help": "help for parameter"}
+        assert get_metadata(some_function, "param", "arg_params") == expected
+
     def test_option_with_invalid_parameter(self):
         with pytest.raises(ValueError):
 


### PR DESCRIPTION
As the title above:+1:
When you find any problem in this PR, please let me know that. I will improve it immediately.

Thanks!